### PR TITLE
Fix releaseset searching, add stand-alone support for multiple server workers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,7 +53,7 @@ class Settings(BaseSettings):
     UNIQUE_USERS_COLLECTION: str = os.getenv("UNIQUE_USERS_COLLECTION", "uniqueUsers")
     REPO_METRICS_COLLECTION: str = os.getenv("REPO_METRICS_COLLECTION", "repoMetrics")
     VERSIONS_COLLECTION: str = os.getenv("VERSIONS_COLLECTION", "versions")
-    RELEASESETS_COLLECTION: str = os.getenv("RELEASESETS_COLLECTION", "releaseSets")
+    RELEASESETS_COLLECTION: str = os.getenv("RELEASESETS_COLLECTION", "releasesets")
     
     # Remote Configuration
     USE_REMOTE_CONFIG: bool = os.getenv("USE_REMOTE_CONFIG", "False").lower() == "true"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,22 +1,27 @@
 #! /bin/bash
-#
-port=8083
-app_module="app.main:app"
-# script=/dev/oar-fm-application-api/python/fm-application-api/run.py
-# [ -f "$script" ] || script=/app/dist/fm-application-api/bin/run.py
+set -euo pipefail
 
-[ -n "$OAR_WORKING_DIR" ] || OAR_WORKING_DIR=`mktemp --tmpdir -d _oar-rmm-python.XXXXX`
-[ -d "$OAR_WORKING_DIR" ] || {
-    echo "oar-rmm-python: ${OAR_WORKING_DIR}: working directory does not exist"
-    exit 10
-}
-[ -n "$OAR_LOG_DIR" ] || export OAR_LOG_DIR=$OAR_WORKING_DIR
+host="${HOST:-0.0.0.0}"
+port="${PORT:-8083}"
+timeout="${TIMEOUT:-120}"
+keep_alive="${KEEP_ALIVE:-5}"
+log_level="${LOG_LEVEL:-info}"
+app_module="app.main:app"
+
+[ -n "${OAR_WORKING_DIR:-}" ] || OAR_WORKING_DIR="$(mktemp -d -t _oar-rmm-python.XXXXXX)"
+[ -d "$OAR_WORKING_DIR" ] || { echo "oar-rmm-python: ${OAR_WORKING_DIR}: working directory does not exist"; exit 10; }
+[ -n "${OAR_LOG_DIR:-}" ] || export OAR_LOG_DIR="$OAR_WORKING_DIR"
 
 echo
 echo "Working Dir: $OAR_WORKING_DIR"
 echo "Access the RMM API at http://localhost:$port/"
 echo
 
-# Update to use uvicorn for FastAPI
-echo "++ uvicorn $app_module --host 0.0.0.0 --port $port"
-exec uvicorn $app_module --host 0.0.0.0 --port $port
+exec gunicorn -k uvicorn.workers.UvicornWorker "$app_module" \
+  --bind "$host:$port" \
+  --timeout "$timeout" \
+  --keep-alive "$keep_alive" \
+  --access-logfile - \
+  --error-logfile - \
+  --log-level "$log_level" \
+  ${WEB_CONCURRENCY:+-w "$WEB_CONCURRENCY"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ tomli==2.2.1
 typing_extensions==4.12.2
 urllib3==2.3.0
 uvicorn==0.34.0
+gunicorn==22.0.0

--- a/scripts/load_test.sh
+++ b/scripts/load_test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+URL="${1:-https://oardev.nist.gov/rmm/records?=&include=ediid,description,title,keyword,topic.tag,contactPoint,components,@type,doi,landingPage&exclude=_id}"
+USERS="${2:-5}"
+REQS="${3:-2}"
+CONNECT_TIMEOUT="${CONNECT_TIMEOUT:-5}"
+MAX_TIME="${MAX_TIME:-180}"
+
+# Determine script directory and output directory
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ts="$(date +%Y%m%d_%H%M%S)"
+out_base="${script_dir}/load_results"
+out_dir="${out_base}/${ts}"
+mkdir -p "${out_dir}"
+
+results="${out_dir}/results.txt"
+parsed="${out_dir}/parsed.txt"
+
+echo "URL: $URL"
+echo "Users: $USERS  Requests/User: $REQS"
+echo "CONNECT_TIMEOUT=${CONNECT_TIMEOUT}s  MAX_TIME=${MAX_TIME}s"
+echo "Output dir: $out_dir"
+echo "Starting..."
+
+run_one() {
+  u=$1 r=$2
+  curl -s -o /dev/null \
+    --connect-timeout "$CONNECT_TIMEOUT" \
+    --max-time "$MAX_TIME" \
+    -w "user=$u req=$r total=%{time_total} start=%{time_starttransfer} size=%{size_download} code=%{http_code}\n" \
+    "$URL"
+}
+
+touch "$results"
+
+for u in $(seq 1 "$USERS"); do
+  for r in $(seq 1 "$REQS"); do
+    (
+      line="$(run_one "$u" "$r")"
+      echo "$line" | tee -a "$results"
+    ) &
+  done
+done
+
+total=$((USERS*REQS))
+while jobs -p >/dev/null 2>&1; do
+  done_count=$(wc -l < "$results")
+  printf "\rCompleted: %d / %d" "$done_count" "$total"
+  [ "$done_count" -ge "$total" ] && break
+  sleep 1
+done
+wait
+echo -e "\nAll done."
+
+awk '/total=/{
+  for(i=1;i<=NF;i++){
+    if($i ~ /^total=/){t=substr($i,7)}
+    if($i ~ /^start=/){s=substr($i,7)}
+    if($i ~ /^size=/){z=substr($i,6)}
+  }
+  print t,s,z
+}' "$results" > "$parsed"
+
+AVG_TOTAL=$(awk '{st+=$1} END{if(NR)printf"%.3f",st/NR}' "$parsed")
+AVG_TTFB=$(awk '{st+=$2} END{if(NR)printf"%.3f",st/NR}' "$parsed")
+AVG_SIZE_MB=$(awk '{st+=$3} END{if(NR)printf"%.2f",(st/NR)/1024/1024}' "$parsed")
+
+pct(){ p=$1; sort -g "$parsed" | awk -v p="$p" '{a[NR]=$1} END{ if(!NR){print"0"} else { idx=int((p/100)*NR); if(idx<1)idx=1; if(idx>NR)idx=NR; printf"%.3f",a[idx] } }'; }
+
+summary="${out_dir}/summary.txt"
+{
+  echo "---- Summary ----"
+  echo "Timestamp: $ts"
+  echo "URL: $URL"
+  echo "Requests: $total"
+  echo "Avg Total (s): $AVG_TOTAL"
+  echo "Avg TTFB  (s): $AVG_TTFB"
+  echo "Avg Size  (MB): $AVG_SIZE_MB"
+  echo "P50: $(pct 50)"
+  echo "P90: $(pct 90)"
+  echo "P95: $(pct 95)"
+  echo "P99: $(pct 99)"
+  echo "Results file: $results"
+  echo "Parsed file:  $parsed"
+} | tee "$summary"
+
+echo "Done. All artifacts saved in: $out_dir"


### PR DESCRIPTION
This PR mainly addresses a bug preventing searches of the `releasesets` collection.  It also includes some updates for running multiple server workers in a stand-alone mode (i.e. not under oar-docker), including a script to test server loading and performance.  
