### PR TITLE
(Metrics) fix: /totalusers and add pagination pipeline to /files

### DIFF
--- a/app/crud/metrics.py
+++ b/app/crud/metrics.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from app.database import db, metrics_db
+from app.crud.metrics_base import MetricsBaseCRUD
 from pymongo import ASCENDING, DESCENDING
 import logging
 import math
@@ -14,6 +15,7 @@ class MetricsCRUD:
         self.file_metrics = metrics_db.fileMetrics
         self.repo_metrics = metrics_db.repoMetrics
         self.unique_users = metrics_db.uniqueUsers
+        self.metrics_base = MetricsBaseCRUD()
 
     def _sanitize_float_for_json(self, value, default_if_non_finite=0):
         """Sanitizes float values that are not JSON compliant (NaN, inf, -inf)."""
@@ -202,50 +204,29 @@ class MetricsCRUD:
             "FilesMetrics": files_metrics
         }
     
-    def get_file_metrics_list(self, sort_by="total_size_download", sort_order=-1):
-        """Get metrics for all files with sorting"""
-        # Determine sort field
-        sort_field = "success_get" if sort_by == "total_size_download" else "filepath"
-        
-        # Get all results with sorting
-        results = list(self.file_metrics.find(
-            {},
-            {"_id": 0, "pdrid": 1, "ediid": 1, "filepath": 1, "downloadURL": 1, 
-            "success_get": 1, "failure_get": 1, "datacart_or_client": 1,
-            "number_users": 1, "total_size_download": 1, "first_time_logged": 1, "last_time_logged": 1}
-        ).sort(sort_field, sort_order))
-        
-        # Format results with sanitization
-        files_metrics = []
-        for result in results:
-            # Sanitize numeric values
-            def sanitize_number(value, default=0):
-                if isinstance(value, (int, float)):
-                    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
-                        return default
-                return value or default
-                
-            files_metrics.append({
-                "pdrid": result.get("pdrid"),
-                "ediid": result.get("ediid"),
-                "filepath": result.get("filepath"),
-                "downloadURL": result.get("downloadURL"),
-                "success_get": sanitize_number(result.get("success_get")),
-                "failure_get": sanitize_number(result.get("failure_get")),
-                "datacart_or_client": sanitize_number(result.get("datacart_or_client")),
-                "total_size_download": sanitize_number(result.get("total_size_download")),
-                "number_users": sanitize_number(result.get("number_users")),
-                "first_time_logged": result.get("first_time_logged"),
-                "last_time_logged": result.get("last_time_logged")
-            })
-        
-        total = len(files_metrics)
-        
-        return {
-            "FilesMetricsCount": total,
-            "PageSize": 0,
-            "FilesMetrics": files_metrics
-        }
+    def get_file_metrics_list(self, params=None):
+        """Get metrics for all files with ProcessRequest paging/sorting support."""
+        params = params or {}
+        params = params.copy()
+
+        # Provide legacy defaults if no explicit sort provided
+        if "sort.desc" not in params and "sort.asc" not in params:
+            params["sort.desc"] = "success_get"
+
+        return self.metrics_base.process_metrics_query(
+            self.file_metrics,
+            params,
+            "FilesMetrics"
+        )
+
+    def get_total_unique_users(self, params=None):
+        """Return paginated total unique user metrics leveraging ProcessRequest compatible params."""
+        params = params or {}
+        return self.metrics_base.process_metrics_query(
+            self.unique_users,
+            params,
+            "TotalUsers"
+        )
 
 metrics_crud = MetricsCRUD()
 

--- a/app/crud/metrics_base.py
+++ b/app/crud/metrics_base.py
@@ -47,22 +47,28 @@ class MetricsBaseCRUD:
         query_data = request.process_search_params(params_copy)
         
         # Get count of total matching documents
-        count = collection.count_documents(query_data["query"])
+        query_filter = query_data.get("query") or {}
+        projection = query_data.get("projection")
+        skip_value = query_data.get("skip") or 0
+        limit_value = query_data.get("limit")
+
+        if not isinstance(limit_value, int) or limit_value < 0:
+            limit_value = 0
+
+        count = collection.count_documents(query_filter)
         
         # Fix sort parameter - handle None or empty sort
         sort_param = query_data.get("sort")
+        base_cursor = collection.find(query_filter, projection)
+
         if not sort_param or (isinstance(sort_param, list) and len(sort_param) == 0):
             # Default sort by last_time_logged if available
-            cursor = collection.find(
-                query_data["query"],
-                query_data["projection"]
-            ).sort([("last_time_logged", DESCENDING)]).skip(query_data["skip"]).limit(query_data["limit"])
+            cursor = base_cursor.sort([("last_time_logged", DESCENDING)])
         else:
             # Use provided sort
-            cursor = collection.find(
-                query_data["query"],
-                query_data["projection"]
-            ).sort(sort_param).skip(query_data["skip"]).limit(query_data["limit"])
+            cursor = base_cursor.sort(sort_param)
+
+        cursor = cursor.skip(skip_value).limit(limit_value)
         
         # Convert to list and handle ObjectIDs
         results = []
@@ -73,13 +79,9 @@ class MetricsBaseCRUD:
             
         result_doc = {
             f"{collection_name}Count": count,
-            "PageSize": query_data["limit"]
+            "PageSize": limit_value
         }
         
-        # For TotalUsers, only return the count
-        if collection_name.lower() == "totalusers":
-            return result_doc
-            
         # Add the metrics data
         result_doc[collection_name] = results
         result_doc["Metrics"] = {

--- a/app/routers/usagemetrics.py
+++ b/app/routers/usagemetrics.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Path, Query, HTTPException
+from fastapi import APIRouter, Path, Query, HTTPException, Request
 from fastapi.responses import JSONResponse
 from typing import Optional
 from app.crud.metrics import metrics_crud
@@ -27,6 +27,16 @@ def sanitize_response(data: dict) -> dict:
         return v
         
     return sanitize_value(data)
+
+def _collapse_query_params(query_params) -> dict:
+    """Flatten multi-value query params by joining repeated keys."""
+    collapsed = {}
+    for key, value in query_params.multi_items():
+        if key in collapsed:
+            collapsed[key] = f"{collapsed[key]},{value}"
+        else:
+            collapsed[key] = value
+    return collapsed
 
 @router.get("/records/{record_id:path}")
 async def get_record_metrics(record_id: str = Path(..., description="Record ID to get metrics for")):
@@ -76,14 +86,33 @@ async def get_file_metrics(file_path: str = Path(..., description="File path to 
 
 @router.get("/files")
 async def get_files_metrics(
-    sort_by: str = Query("downloads", description="Sort by field (downloads or filepath)"),
-    sort_order: str = Query("desc", description="Sort order (asc or desc)")
+    request: Request,
+    page: int = Query(1, ge=1, description="Page number"),
+    size: int = Query(10, ge=0, le=500, description="Page size (0 returns all records)"),
+    sort_by: Optional[str] = Query(
+        None,
+        description="Legacy sort field fallback (downloads or filepath)"
+    ),
+    sort_order: str = Query("desc", description="Legacy sort order (asc or desc)"),
+    sort_desc: Optional[str] = Query(None, alias="sort.desc", description="Comma-separated fields to sort descending"),
+    sort_asc: Optional[str] = Query(None, alias="sort.asc", description="Comma-separated fields to sort ascending")
 ):
-    """Get metrics for all files with sorting"""
-    metrics = metrics_crud.get_file_metrics_list(
-        sort_by=sort_by,
-        sort_order=-1 if sort_order.lower() == "desc" else 1
-    )
+    """Get metrics for all files with paging, sorting, and filtering support."""
+    params = _collapse_query_params(request.query_params)
+    params["page"] = str(page)
+    params["size"] = str(size)
+
+    if sort_desc:
+        params["sort.desc"] = sort_desc
+        params.pop("sort.asc", None)
+    elif sort_asc:
+        params["sort.asc"] = sort_asc
+        params.pop("sort.desc", None)
+    elif sort_by:
+        key = "sort.desc" if sort_order.lower() == "desc" else "sort.asc"
+        params[key] = sort_by
+
+    metrics = metrics_crud.get_file_metrics_list(params)
     return JSONResponse(content=sanitize_response(metrics))
 
 @router.get("/repo")
@@ -93,7 +122,25 @@ async def get_repo_metrics():
     return JSONResponse(content=sanitize_response(metrics))
 
 @router.get("/totalusers")
-async def get_unique_users():
-    """Get total unique users count"""
-    metrics = metrics_crud.get_total_unique_users()
+async def get_unique_users(
+    request: Request,
+    page: int = Query(1, ge=1, description="Page number"),
+    size: int = Query(10, ge=0, le=500, description="Page size (0 returns all records)"),
+    sort_desc: Optional[str] = Query(None, alias="sort.desc", description="Comma-separated fields to sort descending"),
+    sort_asc: Optional[str] = Query(None, alias="sort.asc", description="Comma-separated fields to sort ascending")
+):
+    """Get paginated total unique user metrics matching query filters."""
+    params = _collapse_query_params(request.query_params)
+    params["page"] = str(page)
+    params["size"] = str(size)
+
+    # Only send one explicit sort directive downstream
+    if sort_desc:
+        params["sort.desc"] = sort_desc
+        params.pop("sort.asc", None)
+    elif sort_asc:
+        params["sort.asc"] = sort_asc
+        params.pop("sort.desc", None)
+
+    metrics = metrics_crud.get_total_unique_users(params)
     return JSONResponse(content=sanitize_response(metrics))

--- a/tests/crud/test_crud_metrics.py
+++ b/tests/crud/test_crud_metrics.py
@@ -103,31 +103,45 @@ class TestMetricsCRUDComprehensive(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result["FilesMetricsCount"], 2)
 
-    @patch('app.crud.metrics.metrics_crud.file_metrics')
-    def test_get_file_metrics_list_success(self, mock_collection):
-        """Test get file metrics list with sorting"""
-        mock_collection.find.return_value.sort.return_value = [
-            {
-                "filepath": "file1.txt",
-                "success_get": 100,
-                "total_size_download": 1000
-            }
-        ]
-        
-        result = metrics_crud.get_file_metrics_list(sort_by="total_size_download")
-        
-        self.assertIn("FilesMetricsCount", result)
-        self.assertIn("FilesMetrics", result)
+    @patch('app.crud.metrics.metrics_crud.metrics_base')
+    def test_get_file_metrics_list_uses_metrics_base(self, mock_base):
+        """Ensure file metrics list leverages MetricsBaseCRUD with defaults."""
+        mock_base.process_metrics_query.return_value = {
+            "FilesMetricsCount": 0,
+            "PageSize": 10,
+            "FilesMetrics": [],
+            "Metrics": {"ElapsedTime": 0.0}
+        }
 
-    @patch('app.crud.metrics.metrics_crud.unique_users')
-    def test_get_total_unique_users_method_exists(self, mock_collection):
-        """Test that we can call a method that gets total unique users"""
-        mock_collection.count_documents.return_value = 500
-        
-        # Since get_total_unique_users doesn't exist, let's test the collection directly
-        count = mock_collection.count_documents({})
-        
-        self.assertEqual(count, 500)
+        params = {"page": "2", "size": "5"}
+        result = metrics_crud.get_file_metrics_list(params)
+
+        self.assertEqual(result["PageSize"], 10)
+        mock_base.process_metrics_query.assert_called_once_with(
+            metrics_crud.file_metrics,
+            {"page": "2", "size": "5", "sort.desc": "success_get"},
+            "FilesMetrics"
+        )
+
+    @patch('app.crud.metrics.metrics_crud.metrics_base')
+    def test_get_total_unique_users_uses_metrics_base(self, mock_base):
+        """Ensure total users delegates to MetricsBaseCRUD with params."""
+        mock_base.process_metrics_query.return_value = {
+            "TotalUsersCount": 0,
+            "PageSize": 10,
+            "TotalUsers": [],
+            "Metrics": {"ElapsedTime": 0.0}
+        }
+
+        params = {"page": "1"}
+        result = metrics_crud.get_total_unique_users(params)
+
+        self.assertEqual(result["PageSize"], 10)
+        mock_base.process_metrics_query.assert_called_once_with(
+            metrics_crud.unique_users,
+            params,
+            "TotalUsers"
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/router/test_router_usagemetrics.py
+++ b/tests/router/test_router_usagemetrics.py
@@ -64,11 +64,30 @@ class TestUsageMetricsRouter(unittest.TestCase):
         """Test get all files metrics with sorting"""
         mock_crud.get_file_metrics_list.return_value = {
             "FilesMetricsCount": 5,
+            "PageSize": 3,
             "FilesMetrics": []
         }
         
-        response = self.client.get("/usagemetrics/files?sort_by=downloads&sort_order=desc")
+        response = self.client.get("/usagemetrics/files?page=2&size=3&sort.desc=success_get")
         self.assertEqual(response.status_code, 200)
+        params = mock_crud.get_file_metrics_list.call_args[0][0]
+        self.assertEqual(params["page"], "2")
+        self.assertEqual(params["size"], "3")
+        self.assertEqual(params["sort.desc"], "success_get")
+
+    @patch('app.routers.usagemetrics.metrics_crud')
+    def test_get_files_metrics_legacy_sort_params(self, mock_crud):
+        """Ensure legacy sort_by/sort_order still works."""
+        mock_crud.get_file_metrics_list.return_value = {
+            "FilesMetricsCount": 0,
+            "PageSize": 10,
+            "FilesMetrics": []
+        }
+
+        response = self.client.get("/usagemetrics/files?sort_by=filepath&sort_order=asc")
+        self.assertEqual(response.status_code, 200)
+        params = mock_crud.get_file_metrics_list.call_args[0][0]
+        self.assertEqual(params["sort.asc"], "filepath")
 
     @patch('app.routers.usagemetrics.metrics_crud')
     def test_get_repo_metrics(self, mock_crud):
@@ -85,11 +104,39 @@ class TestUsageMetricsRouter(unittest.TestCase):
     def test_get_unique_users(self, mock_crud):
         """Test get unique users count"""
         mock_crud.get_total_unique_users.return_value = {
-            "total_unique_users": 500
+            "TotalUsersCount": 1,
+            "PageSize": 5,
+            "TotalUsers": [{"month": "2024-01", "count": 500}],
+            "Metrics": {"ElapsedTime": 0.01}
         }
         
-        response = self.client.get("/usagemetrics/totalusers")
+        response = self.client.get("/usagemetrics/totalusers?page=2&size=5&country=US")
         self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["TotalUsersCount"], 1)
+        mock_crud.get_total_unique_users.assert_called_once()
+        params = mock_crud.get_total_unique_users.call_args[0][0]
+        self.assertEqual(params["page"], "2")
+        self.assertEqual(params["size"], "5")
+        self.assertEqual(params["country"], "US")
+
+    @patch('app.routers.usagemetrics.metrics_crud')
+    def test_total_users_merges_duplicate_query_params(self, mock_crud):
+        """Ensure duplicate query params collapse into comma-separated values."""
+        mock_crud.get_total_unique_users.return_value = {
+            "TotalUsersCount": 0,
+            "PageSize": 10,
+            "TotalUsers": [],
+            "Metrics": {"ElapsedTime": 0.0}
+        }
+
+        response = self.client.get(
+            "/usagemetrics/totalusers?country=US&country=CA&sort.desc=timestamp"
+        )
+        self.assertEqual(response.status_code, 200)
+        params = mock_crud.get_total_unique_users.call_args[0][0]
+        self.assertEqual(params["country"], "US,CA")
+        self.assertEqual(params["sort.desc"], "timestamp")
 
     def test_sanitize_response(self):
         """Test response sanitization"""
@@ -115,9 +162,14 @@ class TestUsageMetricsRouter(unittest.TestCase):
     def test_endpoint_accessibility(self, mock_crud):
         """Test that all endpoints are accessible and don't return method not allowed"""
         mock_crud.get_record_metrics_list.return_value = {"DataSetMetricsCount": 0, "DataSetMetrics": []}
-        mock_crud.get_file_metrics_list.return_value = {"FilesMetricsCount": 0, "FilesMetrics": []}
+        mock_crud.get_file_metrics_list.return_value = {"FilesMetricsCount": 0, "PageSize": 0, "FilesMetrics": []}
         mock_crud.get_repo_metrics.return_value = {"RepoMetricsCount": 0, "RepoMetrics": []}
-        mock_crud.get_total_unique_users.return_value = {"total_unique_users": 0}
+        mock_crud.get_total_unique_users.return_value = {
+            "TotalUsersCount": 0,
+            "PageSize": 0,
+            "TotalUsers": [],
+            "Metrics": {"ElapsedTime": 0.0}
+        }
         
         endpoints = [
             "/usagemetrics/records",


### PR DESCRIPTION


# Summary
- ```/usagemetrics/totalusers``` now proxies all filters through ProcessRequest, returns the Java-style envelope (TotalUsersCount, TotalUsers, PageSize, Metrics) and supports paging/sorting.
- ```/usagemetrics/files``` wired to the same pagination pipeline so page/size/sort.* behave correctly instead of dumping the full collection; legacy sort_by/sort_order still honored.
- Router tests updated to cover normalized query forwarding, duplicate parameter collapse, and to assert paging arguments are passed downstream.

# Testing
```shell
pytest tests/router/test_router_usagemetrics.py tests/crud/test_crud_metrics.py
```