### PR TITLE
Simplify /totalusers endpoint response

### DIFF
--- a/app/routers/usagemetrics.py
+++ b/app/routers/usagemetrics.py
@@ -143,4 +143,4 @@ async def get_unique_users(
         params.pop("sort.desc", None)
 
     metrics = metrics_crud.get_total_unique_users(params)
-    return JSONResponse(content=sanitize_response(metrics))
+    return JSONResponse(content=sanitize_response({"TotalUsersCount": metrics.get("TotalUsersCount", 0)}))


### PR DESCRIPTION
# Changes
Modified the ```/usagemetrics/totalusers``` endpoint to return only the total count instead of the full metrics object.