### PR TITLE
fix: return 200 for HEAD requests to / and /rmm/

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -79,6 +79,10 @@ def docs_html_response() -> HTMLResponse:
 async def custom_swagger_ui_html(request: Request):
     return docs_html_response()
 
+@app.head("/", include_in_schema=False)
+async def head_swagger_ui_html():
+    return Response(status_code=200)
+
 @app.get("/rmm/", include_in_schema=False)
 async def custom_swagger_ui_html_rmm(request: Request):
     return docs_html_response()

--- a/app/main.py
+++ b/app/main.py
@@ -69,6 +69,7 @@ app.mount(
 
 
 _DOCS_HTML_CONTENT: str = DOCS_HTML_PATH.read_text(encoding="utf-8")
+_DOCS_CONTENT_LENGTH: str = str(len(_DOCS_HTML_CONTENT.encode("utf-8")))
 
 
 def docs_html_response() -> HTMLResponse:
@@ -81,7 +82,7 @@ async def custom_swagger_ui_html(request: Request):
 
 @app.head("/", include_in_schema=False)
 async def head_swagger_ui_html():
-    return Response(status_code=200)
+    return Response(status_code=200, headers={"Content-Length": _DOCS_CONTENT_LENGTH, "Content-Type": "text/html; charset=utf-8"})
 
 @app.get("/rmm/", include_in_schema=False)
 async def custom_swagger_ui_html_rmm(request: Request):
@@ -89,7 +90,7 @@ async def custom_swagger_ui_html_rmm(request: Request):
 
 @app.head("/rmm/", include_in_schema=False)
 async def head_swagger_ui_html_rmm():
-    return Response(status_code=200)
+    return Response(status_code=200, headers={"Content-Length": _DOCS_CONTENT_LENGTH, "Content-Type": "text/html; charset=utf-8"})
 
 @app.get("/openapi.json", include_in_schema=False)
 async def openapi_schema():

--- a/app/main.py
+++ b/app/main.py
@@ -68,8 +68,11 @@ app.mount(
 )
 
 
-def docs_html_response() -> FileResponse:
-    return FileResponse(DOCS_HTML_PATH)
+_DOCS_HTML_CONTENT: str = DOCS_HTML_PATH.read_text(encoding="utf-8")
+
+
+def docs_html_response() -> HTMLResponse:
+    return HTMLResponse(content=_DOCS_HTML_CONTENT)
 
 
 @app.get("/", include_in_schema=False)
@@ -79,6 +82,10 @@ async def custom_swagger_ui_html(request: Request):
 @app.get("/rmm/", include_in_schema=False)
 async def custom_swagger_ui_html_rmm(request: Request):
     return docs_html_response()
+
+@app.head("/rmm/", include_in_schema=False)
+async def head_swagger_ui_html_rmm():
+    return Response(status_code=200)
 
 @app.get("/openapi.json", include_in_schema=False)
 async def openapi_schema():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,11 @@ class TestMainComprehensive(unittest.TestCase):
         response = self.client.head("/rmm/")
         self.assertEqual(response.status_code, 200)
 
+    def test_root_head_endpoint_returns_200(self):
+        """Test that HEAD / returns 200"""
+        response = self.client.head("/")
+        self.assertEqual(response.status_code, 200)
+
     def test_debug_record_collection_success(self):
         """Test debug record collection endpoint success"""
         response = self.client.get("/debug/record-collection")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,11 @@ class TestMainComprehensive(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/html", response.headers["content-type"])
 
+    def test_rmm_head_endpoint_returns_200(self):
+        """Test that HEAD /rmm/ returns 200"""
+        response = self.client.head("/rmm/")
+        self.assertEqual(response.status_code, 200)
+
     def test_debug_record_collection_success(self):
         """Test debug record collection endpoint success"""
         response = self.client.get("/debug/record-collection")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,14 +14,20 @@ class TestMainComprehensive(unittest.TestCase):
         self.assertIn("text/html", response.headers["content-type"])
 
     def test_rmm_head_endpoint_returns_200(self):
-        """Test that HEAD /rmm/ returns 200"""
+        """Test that HEAD /rmm/ returns 200 with correct headers"""
         response = self.client.head("/rmm/")
         self.assertEqual(response.status_code, 200)
+        self.assertIn("content-length", response.headers)
+        self.assertGreater(int(response.headers["content-length"]), 0)
+        self.assertIn("text/html", response.headers["content-type"])
 
     def test_root_head_endpoint_returns_200(self):
-        """Test that HEAD / returns 200"""
+        """Test that HEAD / returns 200 with correct headers"""
         response = self.client.head("/")
         self.assertEqual(response.status_code, 200)
+        self.assertIn("content-length", response.headers)
+        self.assertGreater(int(response.headers["content-length"]), 0)
+        self.assertIn("text/html", response.headers["content-type"])
 
     def test_debug_record_collection_success(self):
         """Test debug record collection endpoint success"""


### PR DESCRIPTION
``HEAD /rmm/`` and ``HEAD /`` were returning ``405 Method Not Allowed`` because FastAPI does not automatically extend ``GET`` handlers to ``HEAD``. Added explicit ```@app.head(...)``` handlers for both endpoints that return ``200 OK`` with no body, matching correct HTTP semantics. Corresponding tests were added to ``test_main.py``.

# Testing

After deploying, run:


```bash
curl -Ik https://oardev.nist.gov/rmm/
curl -Ik https://oardev.nist.gov/
```

Expected response for both:

```
HTTP/1.1 200 OK
content-type: text/html; charset=utf-8
...
```

Before this fix:

```
HTTP/1.1 405 Method Not Allowed
allow: GET
```