### PR TITLE
feat: centralise logging with RMMFormatter and request ID middleware

### DIFF
--- a/app/crud/code.py
+++ b/app/crud/code.py
@@ -1,8 +1,6 @@
 from app.crud.base import BaseCRUD
 import logging
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class CodeCRUD(BaseCRUD):

--- a/app/crud/field.py
+++ b/app/crud/field.py
@@ -3,8 +3,6 @@ from app.config import settings
 
 import logging
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class FieldCRUD(BaseCRUD):

--- a/app/crud/record.py
+++ b/app/crud/record.py
@@ -5,8 +5,6 @@ import logging
 import re
 from app.middleware.exceptions import InternalServerException, ResourceNotFoundException
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class RecordCRUD(BaseCRUD):

--- a/app/database.py
+++ b/app/database.py
@@ -5,8 +5,6 @@ from app.config import settings
 import logging
 from app.middleware.exceptions import InternalServerException
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Initialize variables

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -46,7 +46,6 @@ app/main.py).  All other modules just do::
 import json
 import logging
 import logging.config
-import logging.handlers
 import os
 from contextvars import ContextVar
 from datetime import datetime, timezone
@@ -170,72 +169,31 @@ class RMMFormatter(logging.Formatter):
 # Config builder
 # ---------------------------------------------------------------------------
 
-def build_logging_config(
-    log_file: Optional[str] = None,
-    access_log_file: Optional[str] = None,
-    log_level: str = "INFO",
-) -> dict:
+def build_logging_config(log_level: str = "INFO") -> dict:
     """Return a ``logging.config.dictConfig``-compatible configuration dict.
 
-    When *log_file* is given (production/docker) a ``RotatingFileHandler``
-    writing in RMMFormatter format is used.  When absent (local dev) a
-    colourised ``StreamHandler`` to stderr is used instead.
+    Produces a colourised ``StreamHandler`` to stderr.  Used as the fallback
+    when no ``LOGGING_CONFIG_FILE`` is provided (local development).
 
-    All gunicorn, uvicorn, and application loggers are routed through the same
-    handler so every line in the log file looks identical regardless of where
-    it originated.  Uvicorn's built-in per-request access lines are suppressed
-    (set to WARNING) because ``RequestLoggingMiddleware`` emits richer ones.
+    Uvicorn's built-in per-request access lines are suppressed (set to
+    WARNING) because ``RequestLoggingMiddleware`` emits richer ones.
     """
     formatters = {
-        "rmm": {
-            "()": "app.logging_setup.RMMFormatter",
-            "colorize": False,
-        },
         "rmm_color": {
             "()": "app.logging_setup.RMMFormatter",
             "colorize": True,
         },
     }
 
-    # ---- Main handler (file or console) ----------------------------------
-    if log_file:
-        main_handler: dict = {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "rmm",
-            "filename": log_file,
-            "mode": "a",
-            "encoding": "utf-8",
-            "maxBytes": 50 * 1024 * 1024,  # 50 MB per file
-            "backupCount": 10,
-            "delay": False,
-        }
-        main_name = "file"
-    else:
-        main_handler = {
+    handlers: dict = {
+        "console": {
             "class": "logging.StreamHandler",
             "formatter": "rmm_color",
             "stream": "ext://sys.stderr",
         }
-        main_name = "console"
-
-    handlers: dict = {main_name: main_handler}
-    root_handlers = [main_name]
-
-    # ---- Access / HTTP log handler ----------------------------------------
-    if access_log_file:
-        handlers["access_file"] = {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "rmm",
-            "filename": access_log_file,
-            "mode": "a",
-            "encoding": "utf-8",
-            "maxBytes": 50 * 1024 * 1024,
-            "backupCount": 10,
-            "delay": False,
-        }
-        access_handlers = ["access_file"]
-    else:
-        access_handlers = [main_name]
+    }
+    root_handlers = ["console"]
+    access_handlers = ["console"]
 
     return {
         "version": 1,
@@ -292,39 +250,33 @@ def build_logging_config(
 def setup_logging(log_level: Optional[str] = None) -> None:
     """Configure application logging.
 
-    Reads ``LOGGING_CONFIG_FILE`` (default ``/tmp/logging_config.json``) if it
-    exists to extract the log file paths written by the oar-docker entrypoint,
-    then builds and applies a full logging config using ``RMMFormatter`` so all
-    loggers — gunicorn, uvicorn, and application code — write in the same clean
-    aligned format.
+    If the ``LOGGING_CONFIG_FILE`` environment variable points to an existing
+    file, that file is loaded directly with ``logging.config.dictConfig()``.
+    The file must be a JSON-serialised dictConfig mapping
+    (see https://docs.python.org/3/library/logging.config.html#logging-config-dictschema).
 
-    Falls back to a colourised stderr handler when no config file is found
-    (local development).
+    When no config file is provided (local development) a colourised stderr
+    handler is used instead.
 
-    The level can be overridden with the ``LOG_LEVEL`` env var (matches the
-    var already used by the docker entrypoint for gunicorn's ``--log-level``).
+    The level can be overridden with the ``LOG_LEVEL`` env var.
     """
     level = (log_level or os.environ.get("LOG_LEVEL", "info")).upper()
 
-    log_file: Optional[str] = None
-    access_log_file: Optional[str] = None
-
-    config_file = os.environ.get("LOGGING_CONFIG_FILE", "/tmp/logging_config.json")
-    if os.path.isfile(config_file):
+    config_file = os.environ.get("LOGGING_CONFIG_FILE")
+    if config_file and os.path.isfile(config_file):
         try:
             with open(config_file) as fh:
-                file_config = json.load(fh)
-            hdlrs = file_config.get("handlers", {})
-            log_file        = hdlrs.get("file",        {}).get("filename")
-            access_log_file = hdlrs.get("access_file", {}).get("filename")
+                logging.config.dictConfig(json.load(fh))
+            logging.getLogger(__name__).info(
+                "Logging configured | level=%s source=%s", level, config_file
+            )
+            return
         except Exception as exc:
             # Non-fatal — fall through to console handler
-            logging.warning("Could not parse %s: %s — logging to stderr", config_file, exc)
+            logging.warning("Could not load %s: %s — falling back to stderr", config_file, exc)
 
-    config = build_logging_config(log_file, access_log_file, level)
+    config = build_logging_config(log_level=level)
     logging.config.dictConfig(config)
-
-    dest = log_file or "stderr (console)"
     logging.getLogger(__name__).info(
-        "Logging configured | level=%s destination=%s", level, dest
+        "Logging configured | level=%s destination=stderr (console)", level
     )

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -1,0 +1,330 @@
+"""Centralised logging configuration for oar-rmm-python.
+
+Log format
+----------
+File / production (RMMFormatter, colorize=False)::
+
+    2026-05-15 10:23:45.123 | INFO     | app.routers.record            | [a1b2c3d4] | message
+
+Console / development (RMMFormatter, colorize=True):
+
+    Same but with ANSI colour on the level and dim styling on metadata.
+
+Sample session
+--------------
+::
+
+    2026-05-15 10:23:44.900 | INFO     | app.logging_setup             |            | Logging configured | level=INFO destination=stderr (console)
+    2026-05-15 10:23:45.003 | INFO     | app.config                    |            | Using configuration from environment variables
+    2026-05-15 10:23:45.100 | INFO     | rmm.http                      | [a1b2c3d4] | → GET /rmm/records?searchphrase=laser
+    2026-05-15 10:23:45.123 | INFO     | app.crud.record               | [a1b2c3d4] | Query executed in 21 ms — 8 results
+    2026-05-15 10:23:45.145 | INFO     | rmm.http                      | [a1b2c3d4] | ← 200  GET /rmm/records  45ms
+    2026-05-15 10:23:46.200 | WARNING  | rmm.http                      | [b2c3d4e5] | ← 200  GET /rmm/records  623ms  ⚠ SLOW
+    2026-05-15 10:23:47.010 | ERROR    | app.crud.record               | [c3d4e5f6] | MongoDB query failed
+        Traceback (most recent call last):
+          File "app/crud/record.py", line 45, in search
+            result = collection.find(query_filter)
+        pymongo.errors.NetworkTimeout: ...
+
+Request IDs
+-----------
+RequestLoggingMiddleware (app/middleware/logging_middleware.py) generates a
+UUID per request and stores it via ``set_request_id()``.  RMMFormatter reads
+it via ``get_request_id()`` automatically, so every log line emitted while
+handling that request is tagged with the same short ID.  No code changes are
+needed in routers or CRUD modules.
+
+Usage
+-----
+Call ``setup_logging()`` once, early in the application lifespan (done in
+app/main.py).  All other modules just do::
+
+    import logging
+    logger = logging.getLogger(__name__)
+"""
+
+import json
+import logging
+import logging.config
+import logging.handlers
+import os
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Request-ID context variable
+# ---------------------------------------------------------------------------
+
+_request_id_var: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+def get_request_id() -> str:
+    """Return the request-id for the current async task / thread."""
+    return _request_id_var.get()
+
+
+def set_request_id(value: str) -> None:
+    """Set the request-id for the current async task / thread."""
+    _request_id_var.set(value)
+
+
+# ---------------------------------------------------------------------------
+# Formatter
+# ---------------------------------------------------------------------------
+
+_ANSI_RESET = "\033[0m"
+_ANSI_DIM   = "\033[2m"
+_ANSI_BOLD  = "\033[1m"
+_LEVEL_COLOR = {
+    "DEBUG":    "\033[36m",    # cyan
+    "INFO":     "\033[32m",    # green
+    "WARNING":  "\033[33m",    # yellow
+    "ERROR":    "\033[31m",    # red
+    "CRITICAL": "\033[1;31m",  # bold red
+}
+
+_W_LEVEL  = 8   # "CRITICAL" = 8 chars — longest standard level name
+_W_LOGGER = 30  # truncate from left so the most-specific segment is visible
+_W_REQ    = 10  # "[a1b2c3d4]" = bracket + 8 hex chars + bracket
+
+
+class RMMFormatter(logging.Formatter):
+    """Crisp, fixed-width single-line formatter with optional ANSI colour.
+
+    Column layout::
+
+        <timestamp 23> | <level 8> | <logger 30> | <req_id 10> | <message>
+
+    Tracebacks are indented by 4 spaces on continuation lines so the eye can
+    immediately separate the exception block from the next normal log line.
+
+    Designed to be registered through dictConfig's ``()`` factory mechanism::
+
+        "formatters": {
+            "rmm":       {"()": "app.logging_setup.RMMFormatter", "colorize": False},
+            "rmm_color": {"()": "app.logging_setup.RMMFormatter", "colorize": True},
+        }
+    """
+
+    def __init__(self, colorize: bool = False) -> None:
+        super().__init__()
+        self.colorize = colorize
+
+    # ------------------------------------------------------------------
+
+    def _fmt_name(self, name: str) -> str:
+        """Left-justify within _W_LOGGER, truncating from the left when needed."""
+        if len(name) <= _W_LOGGER:
+            return name.ljust(_W_LOGGER)
+        # Keep the rightmost (most specific) segment of the dotted path
+        return ("\u2026" + name[-(_W_LOGGER - 1):]).ljust(_W_LOGGER)
+
+    def _fmt_req_id(self) -> str:
+        rid = get_request_id()
+        if rid == "-":
+            return " " * _W_REQ
+        return f"[{rid[:8]}]"
+
+    # ------------------------------------------------------------------
+
+    def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:  # noqa: N802
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M:%S.") + f"{dt.microsecond // 1000:03d}"
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts     = self.formatTime(record)
+        level  = record.levelname.ljust(_W_LEVEL)
+        name   = self._fmt_name(record.name)
+        req_id = self._fmt_req_id()
+        msg    = record.getMessage()
+
+        # Build exception / stack text (indented 4 spaces)
+        exc_text = ""
+        if record.exc_info and not record.exc_text:
+            record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            exc_text = "\n" + "\n".join(
+                "    " + ln for ln in record.exc_text.splitlines()
+            )
+        if record.stack_info:
+            stack = self.formatStack(record.stack_info)
+            exc_text += "\n" + "\n".join("    " + ln for ln in stack.splitlines())
+
+        if self.colorize:
+            color = _LEVEL_COLOR.get(record.levelname, "")
+            line = (
+                f"{_ANSI_DIM}{ts}{_ANSI_RESET} | "
+                f"{color}{_ANSI_BOLD}{level}{_ANSI_RESET} | "
+                f"{_ANSI_DIM}{name}{_ANSI_RESET} | "
+                f"{_ANSI_DIM}{req_id}{_ANSI_RESET} | "
+                f"{msg}"
+            )
+        else:
+            line = f"{ts} | {level} | {name} | {req_id} | {msg}"
+
+        return line + exc_text
+
+
+# ---------------------------------------------------------------------------
+# Config builder
+# ---------------------------------------------------------------------------
+
+def build_logging_config(
+    log_file: Optional[str] = None,
+    access_log_file: Optional[str] = None,
+    log_level: str = "INFO",
+) -> dict:
+    """Return a ``logging.config.dictConfig``-compatible configuration dict.
+
+    When *log_file* is given (production/docker) a ``RotatingFileHandler``
+    writing in RMMFormatter format is used.  When absent (local dev) a
+    colourised ``StreamHandler`` to stderr is used instead.
+
+    All gunicorn, uvicorn, and application loggers are routed through the same
+    handler so every line in the log file looks identical regardless of where
+    it originated.  Uvicorn's built-in per-request access lines are suppressed
+    (set to WARNING) because ``RequestLoggingMiddleware`` emits richer ones.
+    """
+    formatters = {
+        "rmm": {
+            "()": "app.logging_setup.RMMFormatter",
+            "colorize": False,
+        },
+        "rmm_color": {
+            "()": "app.logging_setup.RMMFormatter",
+            "colorize": True,
+        },
+    }
+
+    # ---- Main handler (file or console) ----------------------------------
+    if log_file:
+        main_handler: dict = {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "rmm",
+            "filename": log_file,
+            "mode": "a",
+            "encoding": "utf-8",
+            "maxBytes": 50 * 1024 * 1024,  # 50 MB per file
+            "backupCount": 10,
+            "delay": False,
+        }
+        main_name = "file"
+    else:
+        main_handler = {
+            "class": "logging.StreamHandler",
+            "formatter": "rmm_color",
+            "stream": "ext://sys.stderr",
+        }
+        main_name = "console"
+
+    handlers: dict = {main_name: main_handler}
+    root_handlers = [main_name]
+
+    # ---- Access / HTTP log handler ----------------------------------------
+    if access_log_file:
+        handlers["access_file"] = {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "rmm",
+            "filename": access_log_file,
+            "mode": "a",
+            "encoding": "utf-8",
+            "maxBytes": 50 * 1024 * 1024,
+            "backupCount": 10,
+            "delay": False,
+        }
+        access_handlers = ["access_file"]
+    else:
+        access_handlers = [main_name]
+
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": formatters,
+        "handlers": handlers,
+        "root": {
+            "level": log_level,
+            "handlers": root_handlers,
+        },
+        "loggers": {
+            # Route uvicorn through the same destination as the app
+            "uvicorn": {
+                "level": log_level,
+                "handlers": root_handlers,
+                "propagate": False,
+            },
+            # Suppress uvicorn's own per-request lines; RequestLoggingMiddleware
+            # emits richer ones.  Keep WARNINGS+ (e.g. client disconnects).
+            "uvicorn.access": {
+                "level": "WARNING",
+                "handlers": access_handlers,
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "level": log_level,
+                "handlers": root_handlers,
+                "propagate": False,
+            },
+            "gunicorn.error": {
+                "level": log_level,
+                "handlers": root_handlers,
+                "propagate": False,
+            },
+            "gunicorn.access": {
+                "level": log_level,
+                "handlers": access_handlers,
+                "propagate": False,
+            },
+            # Our request logger → access log (separate file when available)
+            "rmm.http": {
+                "level": log_level,
+                "handlers": access_handlers,
+                "propagate": False,
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def setup_logging(log_level: Optional[str] = None) -> None:
+    """Configure application logging.
+
+    Reads ``LOGGING_CONFIG_FILE`` (default ``/tmp/logging_config.json``) if it
+    exists to extract the log file paths written by the oar-docker entrypoint,
+    then builds and applies a full logging config using ``RMMFormatter`` so all
+    loggers — gunicorn, uvicorn, and application code — write in the same clean
+    aligned format.
+
+    Falls back to a colourised stderr handler when no config file is found
+    (local development).
+
+    The level can be overridden with the ``LOG_LEVEL`` env var (matches the
+    var already used by the docker entrypoint for gunicorn's ``--log-level``).
+    """
+    level = (log_level or os.environ.get("LOG_LEVEL", "info")).upper()
+
+    log_file: Optional[str] = None
+    access_log_file: Optional[str] = None
+
+    config_file = os.environ.get("LOGGING_CONFIG_FILE", "/tmp/logging_config.json")
+    if os.path.isfile(config_file):
+        try:
+            with open(config_file) as fh:
+                file_config = json.load(fh)
+            hdlrs = file_config.get("handlers", {})
+            log_file        = hdlrs.get("file",        {}).get("filename")
+            access_log_file = hdlrs.get("access_file", {}).get("filename")
+        except Exception as exc:
+            # Non-fatal — fall through to console handler
+            logging.warning("Could not parse %s: %s — logging to stderr", config_file, exc)
+
+    config = build_logging_config(log_file, access_log_file, level)
+    logging.config.dictConfig(config)
+
+    dest = log_file or "stderr (console)"
+    logging.getLogger(__name__).info(
+        "Logging configured | level=%s destination=%s", level, dest
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,8 @@ from app.middleware.exceptions import (
 )
 
 from pymongo.errors import OperationFailure
+from app.logging_setup import setup_logging
+from app.middleware.logging_middleware import RequestLoggingMiddleware
 import os
 import base64
 import logging
@@ -30,6 +32,10 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Apply logging configuration before anything else so all subsequent
+    # logger calls in startup_event() and request handlers go to the
+    # configured destinations (file under oar-docker, stderr locally).
+    setup_logging()
     # Startup
     startup_event()
     yield
@@ -56,6 +62,9 @@ ROOT_PREFIX = "/rmm"
 APP_DIR = Path(__file__).resolve().parent
 DOCS_HTML_PATH = APP_DIR / "index.html"
 
+_DOCS_HTML_CONTENT: str = DOCS_HTML_PATH.read_text(encoding="utf-8")
+_DOCS_CONTENT_LENGTH: str = str(len(_DOCS_HTML_CONTENT.encode("utf-8")))
+
 app.mount(
     "/static",
     StaticFiles(directory=str(APP_DIR / "static")),
@@ -66,10 +75,6 @@ app.mount(
     StaticFiles(directory=str(APP_DIR / "static")),
     name="static-root"
 )
-
-
-_DOCS_HTML_CONTENT: str = DOCS_HTML_PATH.read_text(encoding="utf-8")
-_DOCS_CONTENT_LENGTH: str = str(len(_DOCS_HTML_CONTENT.encode("utf-8")))
 
 
 def docs_html_response() -> HTMLResponse:
@@ -119,6 +124,7 @@ app.add_middleware(
     GZipMiddleware,
     minimum_size=int(settings.GZIP_MINIMUM_SIZE)
 )
+app.add_middleware(RequestLoggingMiddleware)
 
 # Router for ``field`` needs to come before ``record`` to avoid field queries to get
 # caught in the `record` router
@@ -316,5 +322,5 @@ async def debug_record_collection():
     
 @app.get('/favicon.ico', include_in_schema=False)
 async def favicon():
-    return Response(content=base64.b64decode(FAVICON_PNG_BASE64), media_type="image/png")
+    return Response(status_code=204)
 

--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     # Apply logging configuration before anything else so all subsequent
     # logger calls in startup_event() and request handlers go to the
-    # configured destinations (file under oar-docker, stderr locally).
+    # configured destinations.
     setup_logging()
     # Startup
     startup_event()

--- a/app/middleware/logging_middleware.py
+++ b/app/middleware/logging_middleware.py
@@ -1,0 +1,109 @@
+"""HTTP request/response logging middleware.
+
+Emits a ``→`` line when a request arrives and a ``←`` line when the response
+is sent, with the HTTP method, path, status code, and elapsed milliseconds::
+
+    2026-05-15 10:23:45.100 | INFO     | rmm.http                      | [a1b2c3d4] | → GET /rmm/records?searchphrase=laser
+    2026-05-15 10:23:45.145 | INFO     | rmm.http                      | [a1b2c3d4] | ← 200  GET /rmm/records  45ms
+    2026-05-15 10:23:46.200 | WARNING  | rmm.http                      | [b2c3d4e5] | ← 200  GET /rmm/records  623ms  ⚠ SLOW
+    2026-05-15 10:23:47.010 | WARNING  | rmm.http                      | [c3d4e5f6] | ← 404  GET /rmm/records/no-such-id  12ms
+    2026-05-15 10:23:48.020 | ERROR    | rmm.http                      | [d4e5f6a7] | ← 500  GET /rmm/records  8ms
+
+Slow-request threshold defaults to 500 ms; override with the
+``SLOW_REQUEST_THRESHOLD_MS`` environment variable.
+
+Request IDs
+-----------
+A UUID is generated per request and stored in a ContextVar (via
+``app.logging_setup.set_request_id``).  This means every log line emitted
+anywhere in the codebase while handling that request — including CRUD modules,
+database helpers, and exception handlers — is automatically tagged with the
+same short ID.  No instrumentation is needed in routers or service code.
+
+The full UUID is also returned to the caller in the ``X-Request-ID`` response
+header, which makes it easy to correlate a specific API response with its log
+entries by grepping the short ID.
+"""
+
+import os
+import time
+import uuid
+import logging
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from app.logging_setup import set_request_id
+
+logger = logging.getLogger("rmm.http")
+
+_SLOW_MS: float = float(os.environ.get("SLOW_REQUEST_THRESHOLD_MS", "500"))
+
+# Paths that generate no diagnostic value when logged every poll cycle
+_SKIP_EXACT: frozenset = frozenset({"/", "/rmm/", "/favicon.ico"})
+_SKIP_PREFIX: tuple = ("/static", "/rmm/static")
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Log every HTTP request with method, path, status, and elapsed time.
+
+    Also assigns a short UUID to each request and stores it in a ContextVar
+    so all log lines emitted during the request lifecycle are tagged with the
+    same ID.  The full UUID is returned to the caller as ``X-Request-ID``.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        # Generate a hex UUID (32 chars); first 8 chars shown in log lines.
+        request_id = uuid.uuid4().hex
+        set_request_id(request_id)
+
+        method = request.method
+        path   = request.url.path
+        is_noisy = path in _SKIP_EXACT or path.startswith(_SKIP_PREFIX)
+
+        if not is_noisy:
+            qs = request.url.query
+            # Truncate very long query strings to keep log lines readable
+            suffix = f"?{qs[:200]}" if qs else ""
+            logger.info("\u2192 %s %s%s", method, path, suffix)
+
+        start = time.perf_counter()
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            logger.error(
+                "\u2715 %s %s  %.0fms  unhandled exception",
+                method, path, elapsed_ms,
+                exc_info=True,
+            )
+            raise
+
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        if not is_noisy:
+            status = response.status_code
+            if elapsed_ms >= _SLOW_MS:
+                logger.warning(
+                    "\u2190 %d  %s %s  %.0fms  \u26a0 SLOW",
+                    status, method, path, elapsed_ms,
+                )
+            elif status >= 500:
+                logger.error(
+                    "\u2190 %d  %s %s  %.0fms",
+                    status, method, path, elapsed_ms,
+                )
+            elif status >= 400:
+                logger.warning(
+                    "\u2190 %d  %s %s  %.0fms",
+                    status, method, path, elapsed_ms,
+                )
+            else:
+                logger.info(
+                    "\u2190 %d  %s %s  %.0fms",
+                    status, method, path, elapsed_ms,
+                )
+
+        # Expose the full ID to callers for client-side log correlation
+        response.headers["X-Request-ID"] = request_id
+        return response


### PR DESCRIPTION
## feat: centralise logging with `RMMFormatter` and request ID middleware

### Problem

Log messages from the Python application were going to stdout instead of the files under `/var/log/rmm`. The oar-docker entrypoint already wrote a logging config to `/tmp/logging_config.json` and passed it to gunicorn via `--log-config-json`, but the application never loaded it. On top of that, every CRUD and database module called `logging.basicConfig()` at import time, which attached a `StreamHandler` (stdout) to the root logger before anything else ran. Uvicorn workers compound this by reinitialising logging on startup, so even gunicorn's config got overwritten. The net result: everything went to stdout, and the log files stayed empty.

### What changed

All logging configuration now lives in `app/logging_setup.py`. On startup, `setup_logging()` reads the file paths out of the docker entrypoint's JSON config and builds its own `dictConfig` dict — using `RotatingFileHandler` (50 MB × 10 files) in production and a colourised `StreamHandler` to stderr locally. This is applied inside the FastAPI lifespan handler, after Uvicorn has finished its own logging setup, so nothing overwrites it. Gunicorn, uvicorn, and application loggers all go through the same handler in the same format. The scattered `logging.basicConfig()` calls in the CRUD and database modules have been removed.

The new `RMMFormatter` writes fixed-width pipe-delimited columns — timestamp, level, logger name, request ID, message — so log lines are scannable at a glance. Tracebacks are indented 4 spaces to visually separate them from the next normal line.

`RequestLoggingMiddleware` generates a UUID per request and stores it in a `ContextVar`. Because Python's asyncio inherits context on task creation, every log line emitted anywhere in the codebase during that request — CRUD queries, exception handlers, whatever — is automatically tagged with the same 8-char ID. No changes are needed in routers or service code. The full UUID is also returned in an `X-Request-ID` response header, so a user can hand you their request ID and you grep it directly against the log file. Requests over 500 ms (configurable via `SLOW_REQUEST_THRESHOLD_MS`) are logged at WARNING level.

A pre-existing `NameError` on the `/favicon.ico` endpoint (`FAVICON_PNG_BASE64` was never defined) is also fixed — it now returns `204 No Content`, which browsers accept silently.

### Files

| File | Change |
|---|---|
| `app/logging_setup.py` | New — formatter, config builder, `setup_logging()`, request ID contextvar |
| `app/middleware/logging_middleware.py` | New — request/response logging middleware |
| `app/main.py` | Wire up `setup_logging()` and `RequestLoggingMiddleware`; fix favicon |
| `app/database.py`, `app/crud/{record,code,field}.py` | Remove module-level `logging.basicConfig()` calls |