### PR TITLE
fix: route application logs to configured log files

### DIFF
--- a/app/crud/code.py
+++ b/app/crud/code.py
@@ -1,8 +1,6 @@
 from app.crud.base import BaseCRUD
 import logging
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class CodeCRUD(BaseCRUD):

--- a/app/crud/field.py
+++ b/app/crud/field.py
@@ -3,8 +3,6 @@ from app.config import settings
 
 import logging
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class FieldCRUD(BaseCRUD):

--- a/app/crud/record.py
+++ b/app/crud/record.py
@@ -5,8 +5,6 @@ import logging
 import re
 from app.middleware.exceptions import InternalServerException, ResourceNotFoundException
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class RecordCRUD(BaseCRUD):

--- a/app/database.py
+++ b/app/database.py
@@ -5,8 +5,6 @@ from app.config import settings
 import logging
 from app.middleware.exceptions import InternalServerException
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Initialize variables

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -1,0 +1,57 @@
+"""Logging configuration for oar-rmm-python.
+
+Call ``setup_logging()`` once during application startup (done in app/main.py).
+
+If the ``LOGGING_CONFIG_FILE`` environment variable points to a JSON file, that
+file is loaded directly with ``logging.config.dictConfig()``.  The file must
+be a valid Python logging dictConfig mapping:
+https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+
+When ``LOGGING_CONFIG_FILE`` is not set (local development), a basic stderr
+handler is configured as a fallback.
+
+The log level can be set with the ``LOG_LEVEL`` environment variable.
+"""
+
+import json
+import logging
+import logging.config
+import os
+from typing import Optional
+
+
+def setup_logging(log_level: Optional[str] = None) -> None:
+    """Configure application logging.
+
+    If the ``LOGGING_CONFIG_FILE`` environment variable points to an existing
+    file, that file is loaded directly with ``logging.config.dictConfig()``.
+    The file must be a JSON-serialised dictConfig mapping.
+
+    Falls back to a stderr handler when no config file is provided.
+
+    The level can be overridden with the ``LOG_LEVEL`` env var.
+    """
+    level = (log_level or os.environ.get("LOG_LEVEL", "info")).upper()
+
+    config_file = os.environ.get("LOGGING_CONFIG_FILE")
+    if config_file and os.path.isfile(config_file):
+        try:
+            with open(config_file) as fh:
+                logging.config.dictConfig(json.load(fh))
+            logging.getLogger(__name__).info(
+                "Logging configured from %s", config_file
+            )
+            return
+        except Exception as exc:
+            logging.warning(
+                "Could not load %s: %s — falling back to stderr", config_file, exc
+            )
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=__import__("sys").stderr,
+    )
+    logging.getLogger(__name__).info(
+        "Logging configured | level=%s destination=stderr", level
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.middleware.exceptions import (
 )
 
 from pymongo.errors import OperationFailure
+from app.logging_setup import setup_logging
 import os
 import base64
 import logging
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    setup_logging()
     # Startup
     startup_event()
     yield


### PR DESCRIPTION
## Fix: route application logs to configured log files

Application logs were being written to stdout instead of the configured log files because scattered `logging.basicConfig()` calls in several modules were locking the root logger to a `StreamHandler` before any deployment-level configuration could take effect.

### Changes

- Added `app/logging_setup.py` with a single `setup_logging()` function. If `LOGGING_CONFIG_FILE` points to a valid [dictConfig](https://docs.python.org/3/library/logging.config.html#logging-config-dictschema) JSON file, it is loaded directly — the app makes no assumptions about its content beyond it being valid Python logging config. Falls back to stderr when the variable is not set (local development).
- `setup_logging()` is called at the start of the FastAPI lifespan, after Uvicorn's worker initialization, so it reliably overrides any prior logging state.
- Removed `logging.basicConfig()` calls from `app/database.py`, `app/crud/record.py`, `app/crud/code.py`, and `app/crud/field.py`.

### oar-docker change required

The entrypoint must write a standard dictConfig JSON file and set `export LOGGING_CONFIG_FILE=<path>` before starting gunicorn. See the updated entrypoint in the linked oar-docker PR [#236](https://github.com/usnistgov/oar-docker/pull/236)